### PR TITLE
Fix crash on iOS 16.3 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # kate-mcmanus-portfolio
 
-Portfolio website for Kate Stryker McManus
+Portfolio website for Kate McManus
 
 ## TODO
 
-- Set up Husky, testing, CI
-- Use MDX for project posts?
+- Fix weird patches of background color on Safari desktop
+- Fix background color change when changing the orientation of the device on old
+  iOS, especially on old devices


### PR DESCRIPTION
## Description

screen.orientation was not supported on iOS 16.3 and below. Given iOS 16.4 was only released in March 2023, a lot of users were likely affected

## Checklist

- [x] Cleaned up the branch commit history with `git rebase -i`, as needed
